### PR TITLE
build: Add support for Phh-Treble

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -78,6 +78,9 @@ function check_product()
     if (echo -n $1 | grep -q -e "^aicp_") ; then
         AICP_BUILD=$(echo -n $1 | sed -e 's/^aicp_//g')
         export BUILD_NUMBER=$( (date +%s%N ; echo $AICP_BUILD; hostname) | openssl sha1 | sed -e 's/.*=//g; s/ //g' | cut -c1-10 )
+    elif (echo -n $1 | grep -q -e "^treble_") ; then
+        AICP_BUILD=$(echo -n $1 | sed -e 's/^treble_//g')
+        export BUILD_NUMBER=$( (date +%s%N ; echo $AICP_BUILD; hostname) | openssl sha1 | sed -e 's/.*=//g; s/ //g' | cut -c1-10 )
     else
         AICP_BUILD=
     fi


### PR DESCRIPTION
Without this patch, version number will be "floko__p-9.0..." if we build Phh-Treble GSI.