### PR TITLE
check_boot_jars: allow CAF

### DIFF
--- a/core/tasks/check_boot_jars/package_whitelist.txt
+++ b/core/tasks/check_boot_jars/package_whitelist.txt
@@ -241,3 +241,6 @@ com\.google\.vr\.platform.*
 ###################################################
 # Packages used for Android in Chrome OS
 org\.chromium\.arc
+
+# CAF
+org\.codeaurora\..*


### PR DESCRIPTION
This is needed to support VoLTE on some devices like OnePlus 7 Pro.